### PR TITLE
Bump react-scroll version

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "react-measure": "^2.0.2",
     "react-modal": "^3.1.10",
     "react-redux": "^5.0.6",
-    "react-scroll": "^1.7.6",
+    "react-scroll": "^1.7.7",
     "react-transition-group": "^2.2.1",
     "redux": "^3.7.2",
     "redux-persist": "^5.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3431,6 +3431,10 @@ lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
 
+lodash.throttle@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
+
 lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
@@ -4878,10 +4882,11 @@ react-redux@^5.0.6:
     loose-envify "^1.1.0"
     prop-types "^15.5.10"
 
-react-scroll@^1.7.6:
-  version "1.7.6"
-  resolved "https://registry.yarnpkg.com/react-scroll/-/react-scroll-1.7.6.tgz#826102e6a9de30142cd8450f190b0fed87171ff6"
+react-scroll@^1.7.7:
+  version "1.7.7"
+  resolved "https://registry.yarnpkg.com/react-scroll/-/react-scroll-1.7.7.tgz#948c40c9a189b62bf4a53ee0fd50e5d89d37260a"
   dependencies:
+    lodash.throttle "^4.1.1"
     prop-types "^15.5.8"
 
 react-scrolllock@^1.0.5:


### PR DESCRIPTION
New version includes PR to use lodash.throttle which fixes performance
degradation problem when adding more events and links in session.

Fixes #27